### PR TITLE
Logger Disable Mask

### DIFF
--- a/include/merase.h
+++ b/include/merase.h
@@ -18,11 +18,12 @@ enum Level {
   INFO,
   WARNING,
   ERROR,
-  CRITICAL
+  CRITICAL,
+  DISABLE
 };
 
-// program log level
-static enum Level _level;
+// program log level (disable by default)
+static enum Level _level = DISABLE;
 
 enum Level logger_get_level();
 void logger_set_level(enum Level level);
@@ -31,8 +32,8 @@ void _info(const char* fmt, ...);
 void _warning(const char* fmt, ...);
 void _error(const char* fmt, ...);
 void _critical(const char* fmt, ...);
-void _log(enum Level level, const char* fmt, va_list argp);
-void out(enum Level level, const char* fmt, va_list argp);
+static void _log(enum Level level, const char* fmt, va_list argp);
+static void out(enum Level level, const char* fmt, va_list argp);
 
 #ifndef critical
 #define critical(...) CRITICAL(__VA_ARGS__, "")

--- a/src/merase.c
+++ b/src/merase.c
@@ -89,7 +89,7 @@ void _error(const char* fmt, ...) {
  * @brief critical log endpoint
  * 
  * @param fmt format string
- * @param ... variable arguments
+ * @param ... variable arguments for string fmt
  */
 void _critical(const char* fmt, ...) {
   va_list args;
@@ -105,7 +105,7 @@ void _critical(const char* fmt, ...) {
  * @param fmt format string
  * @param argp arguments passed to string formatter
  */
-void _log(enum Level level, const char* fmt, va_list argp) {
+static void _log(enum Level level, const char* fmt, va_list argp) {
   // filter output by log level
   if (_level > level) {
     return;
@@ -121,7 +121,7 @@ void _log(enum Level level, const char* fmt, va_list argp) {
  * @param fmt format string
  * @param argp arguments passed to string formatter
  */
-void out(enum Level level, const char* fmt, va_list argp) {
+static void out(enum Level level, const char* fmt, va_list argp) {
   char buffer[256];
   time_t now = time(NULL);
   // set buffer with format string populated with arguments from argp

--- a/src/merase.c
+++ b/src/merase.c
@@ -140,10 +140,8 @@ static void out(enum Level level, const char* fmt, va_list argp) {
     case ERROR:
       fprintf(stderr, "%lis [ERROR] %s\n\r", now, buffer);
       break;
-    case CRITICAL:
-      fprintf(stderr, "%lis [CRITICAL] %s\n\r", now, buffer);
-      break;
     default:
+      fprintf(stderr, "%lis [CRITICAL] %s\n\r", now, buffer);
       break;
   }
   fflush(stderr);

--- a/src/merase.c
+++ b/src/merase.c
@@ -92,7 +92,6 @@ void _error(const char* fmt, ...) {
  * @param ... variable arguments for string fmt
  */
 void _critical(const char* fmt, ...) {
-  int test;
   va_list args;
   va_start(args, fmt);
   _log(CRITICAL, fmt, args);

--- a/src/merase.c
+++ b/src/merase.c
@@ -122,7 +122,7 @@ static void _log(enum Level level, const char* fmt, va_list argp) {
  * @param argp arguments passed to string formatter
  */
 static void out(enum Level level, const char* fmt, va_list argp) {
-  char buffer[256];
+  char buffer[256] = "";
   time_t now = time(NULL);
   // set buffer with format string populated with arguments from argp
   vsnprintf(buffer, sizeof(buffer), fmt, argp);

--- a/src/merase.c
+++ b/src/merase.c
@@ -92,6 +92,7 @@ void _error(const char* fmt, ...) {
  * @param ... variable arguments for string fmt
  */
 void _critical(const char* fmt, ...) {
+  int test;
   va_list args;
   va_start(args, fmt);
   _log(CRITICAL, fmt, args);

--- a/src/merase.c
+++ b/src/merase.c
@@ -107,9 +107,10 @@ void _critical(const char* fmt, ...) {
  */
 void _log(enum Level level, const char* fmt, va_list argp) {
   // filter output by log level
-  if (_level <= level) {
-    out(level, fmt, argp);
+  if (_level > level) {
+    return;
   }
+  out(level, fmt, argp);
 }
 
 /**
@@ -141,6 +142,8 @@ void out(enum Level level, const char* fmt, va_list argp) {
       break;
     case CRITICAL:
       fprintf(stderr, "%lis [CRITICAL] %s\n\r", now, buffer);
+      break;
+    default:
       break;
   }
   fflush(stderr);

--- a/tests/test_merase.cpp
+++ b/tests/test_merase.cpp
@@ -26,7 +26,7 @@ class TestMerase : public testing::Test {
     void SetUp() {
       RESET_FAKE(fprintf);
       FFF_RESET_HISTORY();
-      logger_set_level(TRACE);
+      logger_set_level(DISABLE);
     }
     void TearDown() {}
 };
@@ -42,7 +42,14 @@ TEST_F(TestMerase, TestLogFiltering) {
   ASSERT_EQ(fprintf_fake.call_count, 0);
 }
 
+TEST_F(TestMerase, TestDisable) {
+  const char* msg = "disable log test %d";
+  _critical(msg, 1);
+  ASSERT_EQ(fprintf_fake.call_count, 0);
+}
+
 TEST_F(TestMerase, TestTraceLog) {
+  logger_set_level(TRACE);
   const char* msg = "trace log test %d";
   _trace(msg, 1);
   ASSERT_EQ(fprintf_fake.call_count, 1);
@@ -50,6 +57,7 @@ TEST_F(TestMerase, TestTraceLog) {
 }
 
 TEST_F(TestMerase, TestInfoLog) {
+  logger_set_level(INFO);
   const char* msg = "info log test %d";
   _info(msg, 1);
   ASSERT_EQ(fprintf_fake.call_count, 1);
@@ -57,6 +65,7 @@ TEST_F(TestMerase, TestInfoLog) {
 }
 
 TEST_F(TestMerase, TestWarningLog) {
+  logger_set_level(WARNING);
   const char* msg = "warning log test %d";
   _warning(msg, 1);
   ASSERT_EQ(fprintf_fake.call_count, 1);
@@ -64,6 +73,7 @@ TEST_F(TestMerase, TestWarningLog) {
 }
 
 TEST_F(TestMerase, TestErrorLog) {
+  logger_set_level(ERROR);
   const char* msg = "error log test %d";
   _error(msg, 1);
   ASSERT_EQ(fprintf_fake.call_count, 1);
@@ -71,6 +81,7 @@ TEST_F(TestMerase, TestErrorLog) {
 }
 
 TEST_F(TestMerase, TestCriticalLog) {
+  logger_set_level(CRITICAL);
   const char* msg = "critical log test %d";
   _critical(msg, 1);
   ASSERT_EQ(fprintf_fake.call_count, 1);

--- a/tests/test_merase.cpp
+++ b/tests/test_merase.cpp
@@ -10,9 +10,9 @@
  */
 
 #include <gtest/gtest.h>
-#include <fff.h>
 
 extern "C" {
+  #include <fff.h>
   #include <stdio.h>
   #include "merase.h"
 }
@@ -26,10 +26,10 @@ class TestMerase : public testing::Test {
   public:
     void SetUp() {
       RESET_FAKE(fprintf);
+      RESET_FAKE(fflush);
       FFF_RESET_HISTORY();
       logger_set_level(DISABLE);
     }
-    void TearDown() {}
 };
 
 TEST_F(TestMerase, TestGetSetLogLevel) {


### PR DESCRIPTION
# Description
Adding disable functionality for logger. This feature is mainly for unittesting modules that use the logger. During unittests the default log level will be set to default and so the developer has to explicitly set the logger level to a desired level to activate the logger.

## Resolutions
 - [ ] Add logger disable to level enum
 - [ ] updated unittests

## Linked Issues
closes #1
