### PR TITLE
Variable Logs

### DIFF
--- a/include/merase.h
+++ b/include/merase.h
@@ -25,40 +25,36 @@ enum Level {
 
 enum Level logger_get_level();
 void logger_set_level(enum Level level);
-void _trace(const char *fmt, ...);
-void _info(const char *fmt, ...);
-void _warning(const char *fmt, ...);
-void _error(const char *fmt, ...);
-void _critical(const char *fmt, ...);
+void _log(enum Level level, const char* func, int line, const char* fmt, ...);
 
 #ifndef critical
-#define critical(...) CRITICAL(__VA_ARGS__, "")
-#define CRITICAL(fmt, ...) \
-  _critical("%s:%i " fmt " %s", __func__, __LINE__, __VA_ARGS__)
+#define critical(...) __CRITICAL(__VA_ARGS__, "")
+#define __CRITICAL(fmt, ...) \
+  _log(CRITICAL, __func__, __LINE__, fmt, __VA_ARGS__)
 #endif
 
 #ifndef error
-#define error(...) ERROR(__VA_ARGS__, "")
-#define ERROR(fmt, ...) \
-  _error("%s:%i " fmt " %s", __func__, __LINE__, __VA_ARGS__)
+#define error(...) __ERROR(__VA_ARGS__, "")
+#define __ERROR(fmt, ...) \
+  _log(ERROR, __func__, __LINE__, fmt, __VA_ARGS__)
 #endif
 
 #ifndef warning
-#define warning(...) WARNING(__VA_ARGS__, "")
-#define WARNING(fmt, ...) \
-  _warning("%s:%i " fmt " %s", __func__, __LINE__, __VA_ARGS__)
+#define warning(...) __WARNING(__VA_ARGS__, "")
+#define __WARNING(fmt, ...) \
+  _log(WARNING, __func__, __LINE__, fmt, __VA_ARGS__)
 #endif
 
 #ifndef info
-#define info(...) INFO(__VA_ARGS__, "")
-#define INFO(fmt, ...) \
-  _info("%s:%i " fmt " %s", __func__, __LINE__, __VA_ARGS__)
+#define info(...) __INFO(__VA_ARGS__, "")
+#define __INFO(fmt, ...) \
+  _log(INFO, __func__, __LINE__, fmt, __VA_ARGS__)
 #endif
 
 #ifndef trace
-#define trace(...) TRACE(__VA_ARGS__, "")
-#define TRACE(fmt, ...) \
-  _trace("%s:%i " fmt " %s", __func__, __LINE__, __VA_ARGS__)
+#define trace(...) __TRACE(__VA_ARGS__, "")
+#define __TRACE(fmt, ...) \
+  _log(TRACE, __func__, __LINE__, fmt, __VA_ARGS__)
 #endif
 
 #endif  // MERASE_H_

--- a/include/merase.h
+++ b/include/merase.h
@@ -23,38 +23,38 @@ enum Level {
 };
 
 
-enum Level logger_get_level();
-void logger_set_level(enum Level level);
-void _log(enum Level level, const char* func, int line, const char* fmt, ...);
+enum Level merase_get_level();
+void merase_set_level(enum Level level);
+void merase_log(enum Level level, const char* func, int line, const char* fmt, ...);
 
 #ifndef critical
 #define critical(...) __CRITICAL(__VA_ARGS__, "")
 #define __CRITICAL(fmt, ...) \
-  _log(CRITICAL, __func__, __LINE__, fmt, __VA_ARGS__)
+  merase_log(CRITICAL, __func__, __LINE__, fmt, __VA_ARGS__)
 #endif
 
 #ifndef error
 #define error(...) __ERROR(__VA_ARGS__, "")
 #define __ERROR(fmt, ...) \
-  _log(ERROR, __func__, __LINE__, fmt, __VA_ARGS__)
+  merase_log(ERROR, __func__, __LINE__, fmt, __VA_ARGS__)
 #endif
 
 #ifndef warning
 #define warning(...) __WARNING(__VA_ARGS__, "")
 #define __WARNING(fmt, ...) \
-  _log(WARNING, __func__, __LINE__, fmt, __VA_ARGS__)
+  merase_log(WARNING, __func__, __LINE__, fmt, __VA_ARGS__)
 #endif
 
 #ifndef info
 #define info(...) __INFO(__VA_ARGS__, "")
 #define __INFO(fmt, ...) \
-  _log(INFO, __func__, __LINE__, fmt, __VA_ARGS__)
+  merase_log(INFO, __func__, __LINE__, fmt, __VA_ARGS__)
 #endif
 
 #ifndef trace
 #define trace(...) __TRACE(__VA_ARGS__, "")
 #define __TRACE(fmt, ...) \
-  _log(TRACE, __func__, __LINE__, fmt, __VA_ARGS__)
+  merase_log(TRACE, __func__, __LINE__, fmt, __VA_ARGS__)
 #endif
 
 #endif  // MERASE_H_

--- a/include/merase.h
+++ b/include/merase.h
@@ -25,11 +25,11 @@ enum Level {
 
 enum Level logger_get_level();
 void logger_set_level(enum Level level);
-void _trace(const char* fmt, ...);
-void _info(const char* fmt, ...);
-void _warning(const char* fmt, ...);
-void _error(const char* fmt, ...);
-void _critical(const char* fmt, ...);
+void _trace(const char *fmt, ...);
+void _info(const char *fmt, ...);
+void _warning(const char *fmt, ...);
+void _error(const char *fmt, ...);
+void _critical(const char *fmt, ...);
 
 #ifndef critical
 #define critical(...) CRITICAL(__VA_ARGS__, "")

--- a/src/merase.c
+++ b/src/merase.c
@@ -16,10 +16,10 @@
 #include "merase.h"
 
 struct __std_log {
-  FILE* fp;
+  FILE *fp;
   int line;
-  va_list argp;
-  const char* fmt;
+  va_list *argp;
+  const char *fmt;
   const char *repr;
   const char *func;
 };
@@ -69,7 +69,7 @@ void merase_log(enum Level level, const char* func, int line, const char* fmt, .
     stdl.fp = stdout;
   }
   stdl.repr = _get_level_str(level);
-  stdl.argp = args;
+  stdl.argp = &args;
   stdl.fmt = fmt;
   stdl.func = func;
   stdl.line = line;
@@ -107,7 +107,7 @@ static void _out(struct __std_log *stdl) {
   pthread_mutex_lock(&s_mutx);
   fprintf(fp, "%ld [%s]\t %s:%i ",
     now, stdl->repr, stdl->func, stdl->line);
-  vfprintf(fp, stdl->fmt, stdl->argp);
+  vfprintf(fp, stdl->fmt, *stdl->argp);
   fprintf(fp, "\n\r");
   fflush(fp);
   pthread_mutex_unlock(&s_mutx);

--- a/src/merase.c
+++ b/src/merase.c
@@ -15,6 +15,10 @@
 #include <pthread.h>
 #include "merase.h"
 
+/**
+ * @brief Standard logging struct
+ * 
+ */
 struct __std_log {
   FILE *fp;
   int line;
@@ -49,11 +53,13 @@ enum Level merase_get_level() {
 }
 
 /**
- * @brief Filter logs by log level.
+ * @brief Perform log filtration and standard log construction parsing variable arguments
  * 
- * @param level log level
- * @param fmt format string
- * @param argp arguments passed to string formatter
+ * @param level log level enum
+ * @param func macro expanded log containing function name
+ * @param line macro expanded log line
+ * @param fmt log string formatter
+ * @param ... variable arguments for string formatter
  */
 void merase_log(enum Level level, const char* func, int line, const char* fmt, ...) {
   va_list args;
@@ -80,7 +86,7 @@ void merase_log(enum Level level, const char* func, int line, const char* fmt, .
 /**
  * @brief Get the string representation of log level enum
  * 
- * @param level log level
+ * @param level log level enum
  * @return char* 
  */
 static char *_get_level_str(enum Level level) {
@@ -95,11 +101,9 @@ static char *_get_level_str(enum Level level) {
 }
 
 /**
- * @brief Pre log message formatting and file write function
+ * @brief Static IO output function for log message
  * 
- * @param level log level
- * @param fmt format string
- * @param argp arguments passed to string formatter
+ * @param stdl standard log out struct containing log metrics
  */
 static void _out(struct __std_log *stdl) {
   time_t now = time(NULL);

--- a/src/merase.c
+++ b/src/merase.c
@@ -95,8 +95,7 @@ static char *_get_level_str(enum Level level) {
     case INFO: return "INFO";
     case WARNING: return "WARN";
     case ERROR: return "ERROR";
-    case CRITICAL: return "CRIT";
-    default: return "NULL";
+    default: return "CRIT";
   }
 }
 

--- a/src/merase.c
+++ b/src/merase.c
@@ -27,15 +27,15 @@ struct __std_log {
 // program log level (disable by default)
 static enum Level _level = DISABLE;
 static pthread_mutex_t s_mutx;
-static char *get_level_str(enum Level level);
-static void out(struct __std_log *stdl);
+static char *_get_level_str(enum Level level);
+static void _out(struct __std_log *stdl);
 
 /**
  * @brief Set the program log level
  * 
  * @param level target logging level
  */
-void logger_set_level(enum Level level) {
+void merase_set_level(enum Level level) {
   _level = level;
 }
 
@@ -44,7 +44,7 @@ void logger_set_level(enum Level level) {
  * 
  * @return enum Level 
  */
-enum Level logger_get_level() {
+enum Level merase_get_level() {
   return _level;
 }
 
@@ -55,7 +55,7 @@ enum Level logger_get_level() {
  * @param fmt format string
  * @param argp arguments passed to string formatter
  */
-void _log(enum Level level, const char* func, int line, const char* fmt, ...) {
+void merase_log(enum Level level, const char* func, int line, const char* fmt, ...) {
   va_list args;
   va_start(args, fmt);
   // filter output by log level
@@ -68,12 +68,12 @@ void _log(enum Level level, const char* func, int line, const char* fmt, ...) {
   } else {
     stdl.fp = stdout;
   }
-  stdl.repr = get_level_str(level);
+  stdl.repr = _get_level_str(level);
   stdl.argp = args;
   stdl.fmt = fmt;
   stdl.func = func;
   stdl.line = line;
-  out(&stdl);
+  _out(&stdl);
   va_end(args);
 }
 
@@ -83,7 +83,7 @@ void _log(enum Level level, const char* func, int line, const char* fmt, ...) {
  * @param level log level
  * @return char* 
  */
-static char *get_level_str(enum Level level) {
+static char *_get_level_str(enum Level level) {
   switch (level) {
     case TRACE: return "TRACE";
     case INFO: return "INFO";
@@ -101,7 +101,7 @@ static char *get_level_str(enum Level level) {
  * @param fmt format string
  * @param argp arguments passed to string formatter
  */
-static void out(struct __std_log *stdl) {
+static void _out(struct __std_log *stdl) {
   time_t now = time(NULL);
   FILE *fp = stdl->fp;
   pthread_mutex_lock(&s_mutx);

--- a/tests/test_merase.cpp
+++ b/tests/test_merase.cpp
@@ -14,13 +14,17 @@
 extern "C" {
   #include <fff.h>
   #include <stdio.h>
+  #include <pthread.h>
   #include "merase.h"
 }
 
 
 DEFINE_FFF_GLOBALS;
 FAKE_VALUE_FUNC_VARARG(int, fprintf, FILE *, const char *, ...);
+FAKE_VALUE_FUNC3(int, vfprintf, FILE *, const char *, char *);
 FAKE_VALUE_FUNC1(int, fflush, FILE *);
+FAKE_VALUE_FUNC1(int, pthread_mutex_lock, pthread_mutex_t *)
+FAKE_VALUE_FUNC1(int, pthread_mutex_unlock, pthread_mutex_t *)
 
 class TestMerase : public testing::Test {
   public:
@@ -28,78 +32,63 @@ class TestMerase : public testing::Test {
       RESET_FAKE(fprintf);
       RESET_FAKE(fflush);
       FFF_RESET_HISTORY();
-      logger_set_level(DISABLE);
+      merase_set_level(DISABLE);
     }
 };
 
 TEST_F(TestMerase, TestGetSetLogLevel) {
   for (int i=TRACE; i <= DISABLE; i++) {
-    logger_set_level((Level)i);
-    ASSERT_EQ(logger_get_level(), (Level)i);
+    merase_set_level((Level)i);
+    ASSERT_EQ(merase_get_level(), (Level)i);
   }
 }
 
 TEST_F(TestMerase, TestLogFiltering) {
   const char* fmt = "filtration test";
-  for (int i=TRACE; i <= DISABLE; i++) {
-    logger_set_level((Level)i);
-    switch (i) {
-      case INFO:
-        _trace(fmt);
-        break;
-      case WARNING:
-        _info(fmt);
-        break;
-      case ERROR:
-        _warning(fmt);
-        break;
-      case CRITICAL:
-        _error(fmt);
-        break;
-      case DISABLE:
-        _critical(fmt);
-        break;
-    }
-    ASSERT_EQ(fprintf_fake.call_count, 0);
+  // test up to but not including TRACE (no filtering)
+  for (int i=DISABLE; i > TRACE; i--) {
+    merase_set_level((Level)i);
+    merase_log((Level)(i - 1), __func__, __LINE__, "%d", 1);
+    ASSERT_EQ(vfprintf_fake.call_count, 0);
   }
 }
 
-TEST_F(TestMerase, TestTraceLog) {
-  logger_set_level(TRACE);
-  const char* msg = "trace log test %d";
-  _trace(msg, 1);
-  ASSERT_EQ(fprintf_fake.call_count, 1);
-  ASSERT_EQ(fprintf_fake.arg0_val, stdout);
-}
+// TEST_F(TestMerase, TestTraceLog) {
+//   merase_set_level(TRACE);
+//   const char* msg = "trace log test %d";
+//   _trace(msg, 1);
+//   ASSERT_EQ(fprintf_fake.call_count, 1);
+//   ASSERT_EQ(fprintf_fake.arg0_val, stdout);
+// }
 
-TEST_F(TestMerase, TestInfoLog) {
-  logger_set_level(INFO);
-  const char* msg = "info log test %d";
-  _info(msg, 1);
-  ASSERT_EQ(fprintf_fake.call_count, 1);
-  ASSERT_EQ(fprintf_fake.arg0_val, stdout);
-}
+// TEST_F(TestMerase, TestInfoLog) {
+//   logger_set_level(INFO);
+//   const char* msg = "info log test %d";
+//   _info(msg, 1);
+//   ASSERT_EQ(fprintf_fake.call_count, 1);
+//   ASSERT_EQ(fprintf_fake.arg0_val, stdout);
+// }
 
-TEST_F(TestMerase, TestWarningLog) {
-  logger_set_level(WARNING);
-  const char* msg = "warning log test %d";
-  _warning(msg, 1);
-  ASSERT_EQ(fprintf_fake.call_count, 1);
-  ASSERT_EQ(fprintf_fake.arg0_val, stdout);
-}
+// TEST_F(TestMerase, TestWarningLog) {
+//   logger_set_level(WARNING);
+//   const char* msg = "warning log test %d";
+//   _warning(msg, 1);
+//   ASSERT_EQ(fprintf_fake.call_count, 1);
+//   ASSERT_EQ(fprintf_fake.arg0_val, stdout);
+// }
 
-TEST_F(TestMerase, TestErrorLog) {
-  logger_set_level(ERROR);
-  const char* msg = "error log test %d";
-  _error(msg, 1);
-  ASSERT_EQ(fprintf_fake.call_count, 1);
-  ASSERT_EQ(fprintf_fake.arg0_val, stderr);
-}
+// TEST_F(TestMerase, TestErrorLog) {
+//   logger_set_level(ERROR);
+//   const char* msg = "error log test %d";
+//   _error(msg, 1);
+//   ASSERT_EQ(fprintf_fake.call_count, 1);
+//   ASSERT_EQ(fprintf_fake.arg0_val, stderr);
+// }
 
-TEST_F(TestMerase, TestCriticalLog) {
-  logger_set_level(CRITICAL);
-  const char* msg = "critical log test %d";
-  _critical(msg, 1);
-  ASSERT_EQ(fprintf_fake.call_count, 1);
-  ASSERT_EQ(fprintf_fake.arg0_val, stderr);
-}
+// TEST_F(TestMerase, TestCriticalLog) {
+//   logger_set_level(CRITICAL);
+//   const char* msg = "critical log test %d";
+//   _critical(msg, 1);
+//   ASSERT_EQ(fprintf_fake.call_count, 1);
+//   ASSERT_EQ(fprintf_fake.arg0_val, stderr);
+// }

--- a/tests/test_merase.cpp
+++ b/tests/test_merase.cpp
@@ -22,6 +22,7 @@ extern "C" {
 
 DEFINE_FFF_GLOBALS;
 FAKE_VALUE_FUNC_VARARG(int, fprintf, FILE *, const char *, ...);
+FAKE_VALUE_FUNC1(time_t, time, time_t *);
 FAKE_VALUE_FUNC3(int, vfprintf, FILE *, const char *, va_list);
 FAKE_VALUE_FUNC1(int, fflush, FILE *);
 FAKE_VALUE_FUNC1(int, pthread_mutex_lock, pthread_mutex_t *)
@@ -32,6 +33,10 @@ class TestMerase : public testing::Test {
     void SetUp() {
       RESET_FAKE(fprintf);
       RESET_FAKE(fflush);
+      RESET_FAKE(time);
+      RESET_FAKE(vfprintf);
+      RESET_FAKE(pthread_mutex_lock);
+      RESET_FAKE(pthread_mutex_unlock);
       FFF_RESET_HISTORY();
       merase_set_level(DISABLE);
     }
@@ -54,42 +59,67 @@ TEST_F(TestMerase, TestLogFiltering) {
   }
 }
 
-// TEST_F(TestMerase, TestTraceLog) {
-//   merase_set_level(TRACE);
-//   const char* msg = "trace log test %d";
-//   _trace(msg, 1);
-//   ASSERT_EQ(fprintf_fake.call_count, 1);
-//   ASSERT_EQ(fprintf_fake.arg0_val, stdout);
-// }
+TEST_F(TestMerase, TestTraceLog) {
+  merase_set_level(TRACE);
+  const char *fmt = "%d";
+  merase_log(TRACE, __func__, __LINE__, fmt, 1);
+  ASSERT_EQ(vfprintf_fake.call_count, 1);
+  ASSERT_EQ(vfprintf_fake.arg0_val, stdout);
+  ASSERT_EQ(fprintf_fake.arg0_history[0], stdout);
+  ASSERT_EQ(strcmp(vfprintf_fake.arg1_val, fmt), 0);
+  ASSERT_EQ(pthread_mutex_lock_fake.call_count, 1);
+  ASSERT_EQ(pthread_mutex_unlock_fake.call_count, 1);
+  ASSERT_EQ(time_fake.call_count, 1);
+}
 
-// TEST_F(TestMerase, TestInfoLog) {
-//   logger_set_level(INFO);
-//   const char* msg = "info log test %d";
-//   _info(msg, 1);
-//   ASSERT_EQ(fprintf_fake.call_count, 1);
-//   ASSERT_EQ(fprintf_fake.arg0_val, stdout);
-// }
+TEST_F(TestMerase, TestInfoLog) {
+  merase_set_level(INFO);
+  const char *fmt = "%d";
+  merase_log(INFO, __func__, __LINE__, fmt, 1);
+  ASSERT_EQ(vfprintf_fake.call_count, 1);
+  ASSERT_EQ(vfprintf_fake.arg0_val, stdout);
+  ASSERT_EQ(fprintf_fake.arg0_history[0], stdout);
+  ASSERT_EQ(strcmp(vfprintf_fake.arg1_val, fmt), 0);
+  ASSERT_EQ(pthread_mutex_lock_fake.call_count, 1);
+  ASSERT_EQ(pthread_mutex_unlock_fake.call_count, 1);
+  ASSERT_EQ(time_fake.call_count, 1);
+}
 
-// TEST_F(TestMerase, TestWarningLog) {
-//   logger_set_level(WARNING);
-//   const char* msg = "warning log test %d";
-//   _warning(msg, 1);
-//   ASSERT_EQ(fprintf_fake.call_count, 1);
-//   ASSERT_EQ(fprintf_fake.arg0_val, stdout);
-// }
+TEST_F(TestMerase, TestWarningLog) {
+  merase_set_level(WARNING);
+  const char *fmt = "%d";
+  merase_log(WARNING, __func__, __LINE__, fmt, 1);
+  ASSERT_EQ(vfprintf_fake.call_count, 1);
+  ASSERT_EQ(vfprintf_fake.arg0_val, stdout);
+  ASSERT_EQ(fprintf_fake.arg0_history[0], stdout);
+  ASSERT_EQ(strcmp(vfprintf_fake.arg1_val, fmt), 0);
+  ASSERT_EQ(pthread_mutex_lock_fake.call_count, 1);
+  ASSERT_EQ(pthread_mutex_unlock_fake.call_count, 1);
+  ASSERT_EQ(time_fake.call_count, 1);
+}
 
-// TEST_F(TestMerase, TestErrorLog) {
-//   logger_set_level(ERROR);
-//   const char* msg = "error log test %d";
-//   _error(msg, 1);
-//   ASSERT_EQ(fprintf_fake.call_count, 1);
-//   ASSERT_EQ(fprintf_fake.arg0_val, stderr);
-// }
+TEST_F(TestMerase, TestErrorLog) {
+  merase_set_level(ERROR);
+  const char *fmt = "%d";
+  merase_log(ERROR, __func__, __LINE__, fmt, 1);
+  ASSERT_EQ(vfprintf_fake.call_count, 1);
+  ASSERT_EQ(vfprintf_fake.arg0_val, stderr);
+  ASSERT_EQ(fprintf_fake.arg0_history[0], stderr);
+  ASSERT_EQ(strcmp(vfprintf_fake.arg1_val, fmt), 0);
+  ASSERT_EQ(pthread_mutex_lock_fake.call_count, 1);
+  ASSERT_EQ(pthread_mutex_unlock_fake.call_count, 1);
+  ASSERT_EQ(time_fake.call_count, 1);
+}
 
-// TEST_F(TestMerase, TestCriticalLog) {
-//   logger_set_level(CRITICAL);
-//   const char* msg = "critical log test %d";
-//   _critical(msg, 1);
-//   ASSERT_EQ(fprintf_fake.call_count, 1);
-//   ASSERT_EQ(fprintf_fake.arg0_val, stderr);
-// }
+TEST_F(TestMerase, TestCriticalLog) {
+  merase_set_level(CRITICAL);
+  const char *fmt = "%d";
+  merase_log(CRITICAL, __func__, __LINE__, fmt, 1);
+  ASSERT_EQ(vfprintf_fake.call_count, 1);
+  ASSERT_EQ(vfprintf_fake.arg0_val, stderr);
+  ASSERT_EQ(fprintf_fake.arg0_history[0], stderr);
+  ASSERT_EQ(strcmp(vfprintf_fake.arg1_val, fmt), 0);
+  ASSERT_EQ(pthread_mutex_lock_fake.call_count, 1);
+  ASSERT_EQ(pthread_mutex_unlock_fake.call_count, 1);
+  ASSERT_EQ(time_fake.call_count, 1);
+}

--- a/tests/test_merase.cpp
+++ b/tests/test_merase.cpp
@@ -15,13 +15,14 @@ extern "C" {
   #include <fff.h>
   #include <stdio.h>
   #include <pthread.h>
+  #include <stdarg.h>
   #include "merase.h"
 }
 
 
 DEFINE_FFF_GLOBALS;
 FAKE_VALUE_FUNC_VARARG(int, fprintf, FILE *, const char *, ...);
-FAKE_VALUE_FUNC3(int, vfprintf, FILE *, const char *, char *);
+FAKE_VALUE_FUNC3(int, vfprintf, FILE *, const char *, va_list);
 FAKE_VALUE_FUNC1(int, fflush, FILE *);
 FAKE_VALUE_FUNC1(int, pthread_mutex_lock, pthread_mutex_t *)
 FAKE_VALUE_FUNC1(int, pthread_mutex_unlock, pthread_mutex_t *)


### PR DESCRIPTION
# Description
Fix log size constraint by printing variable string size as passed by variable arguments. Implement mutex lock during file io operations. Simplify api internal specification and add namespace prefix to all public endpoints: `merase_*`

## Resolutions
 - [x] use pthread mutex lock for io operations
 - [x] enable variable sized log message
 - [x] aggregate logging endpoints for all levels to a single function handler
 - [x] add namespace prefix to public endpoints
